### PR TITLE
update google analytics plugin to use latest `gtag.js`

### DIFF
--- a/layout/partial/google_analytics.jade
+++ b/layout/partial/google_analytics.jade
@@ -1,16 +1,8 @@
 if theme.google_analytics
+    script(async=true, src="https://www.googletagmanager.com/gtag/js?id=#{theme.google_analytics}")
     script.
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r;
-            i[r] = i[r] || function () {
-                        (i[r].q = i[r].q || []).push(arguments)
-                    }, i[r].l = 1 * new Date();
-            a = s.createElement(o),
-                    m = s.getElementsByTagName(o)[0];
-            a.async = 1;
-            a.src = g;
-            m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-        ga('create', '#{theme.google_analytics}', 'auto');
-        ga('send', 'pageview');
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
+        gtag('config', '#{theme.google_analytics}');


### PR DESCRIPTION
Currently, it's using `analytics.js`, according to <https://developers.google.com/analytics/devguides/collection/upgrade/> and <https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs>, it's recommended to use `gtag.js` for a "modern measurement library".

I was using old `analytics.js` and found that my google analytics has been receiving no data for more than one year...