### PR TITLE
Fix broken link for bootstrap 3.3.7 from old cdn

### DIFF
--- a/layout/partial/footer-scripts.jade
+++ b/layout/partial/footer-scripts.jade
@@ -1,5 +1,5 @@
 script(src="//cdn.bootcss.com/jquery/1.11.2/jquery.min.js")
-script(src="//cdn.bootcss.com/bootstrap/3.3.7/js/bootstrap.min.js")
+script(src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js")
 script(src=url_for("/js/main.js"))
 
 if theme.highlight.enable

--- a/layout/partial/head.jade
+++ b/layout/partial/head.jade
@@ -14,7 +14,7 @@ block description
 link(rel="alternate", type="application/rss+xml", title=config.title, href=url_for("/atom.xml"))
 
 link(rel="stylesheet", href="//cdn.bootcss.com/font-awesome/4.5.0/css/font-awesome.min.css")
-link(rel="stylesheet", href="//cdn.bootcss.com/bootstrap/3.3.7/css/bootstrap.min.css")
+link(rel="stylesheet", href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css")
 link(rel="stylesheet", href=url_for("/css/main.css"))
 
 if theme.highlight.enable


### PR DESCRIPTION
The old link at <cdn.bootcss.com/bootstrap/3.3.7/js/bootstrap.min.js> is broken at least since 01/29/2022, replace with another link.